### PR TITLE
feat(tts): integrate Kokoro-FastAPI TTS (CPU, OpenAI-compatible)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,17 @@ PRICE_GOOGLE_SHEET_ID=
 ENABLE_OAUTH=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# ============================================================
+# Kokoro TTS
+# Tiếng Việt: đang trong lộ trình — https://github.com/hexgrad/kokoro
+# Khi có tiếng Việt: đổi KOKORO_DEFAULT_VOICE thành voice vi-VN
+# ============================================================
+KOKORO_PORT=8880
+KOKORO_DEFAULT_VOICE=af_heart
+
+# Voices có sẵn (English/Korean/Japanese):
+# af_heart, af_bella, af_sarah — English female
+# am_adam, am_michael       — English male
+# bf_emma, bf_isabella      — British female
+# bm_george, bm_lewis       — British male

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: dev stop logs ingest ingest-pdf ingest-md backup 
-        test test-unit test-int coverage lint format typecheck 
-        shell-rag pull-model logs-webui list-models 
-        shell-webui status
+.PHONY: dev stop logs ingest ingest-pdf ingest-md backup \
+        test test-unit test-int coverage lint format typecheck \
+        shell-rag pull-model logs-webui list-models \
+        shell-webui status tts-voices tts-test tts-test-vi logs-tts
 
 COMPOSE=docker compose -f infra/docker-compose.yml
 
@@ -78,3 +78,31 @@ qdrant-reset:
 	docker volume rm bazan-qdrant-data || true
 	$(COMPOSE) up -d qdrant
 	@echo "Qdrant data cleared and restarted"
+
+# TTS
+tts-voices:
+	@echo "=== Kokoro TTS voices ==="
+	curl -s http://localhost:$${KOKORO_PORT:-8880}/v1/voices \
+	  | python3 -c "import sys,json; voices=json.load(sys.stdin).get('voices',[]); [print(f'  {v[\"voice_id\"]:20} {v.get(\"name\",\"\")}') for v in voices]"
+
+tts-test:
+	@echo "=== Generating test audio ==="
+	curl -s http://localhost:$${KOKORO_PORT:-8880}/v1/audio/speech \
+	  -H "Content-Type: application/json" \
+	  -d '{"model":"kokoro","input":"Hello, this is Bazan AI coffee assistant. Vietnamese voice coming soon.","voice":"$${KOKORO_DEFAULT_VOICE:-af_heart}","response_format":"wav"}' \
+	  --output /tmp/bazan-tts-test.wav \
+	  && echo "Saved: /tmp/bazan-tts-test.wav" \
+	  && { command -v afplay && afplay /tmp/bazan-tts-test.wav; } \
+	  || { command -v aplay && aplay /tmp/bazan-tts-test.wav; } \
+	  || echo "Play manually: open /tmp/bazan-tts-test.wav"
+
+tts-test-vi:
+	@echo "=== Vietnamese text (English voice — temp) ==="
+	curl -s http://localhost:$${KOKORO_PORT:-8880}/v1/audio/speech \
+	  -H "Content-Type: application/json" \
+	  -d '{"model":"kokoro","input":"Gia ca ca phe hom nay tai Dak Lak la 65 nghin dong mot ky.","voice":"$${KOKORO_DEFAULT_VOICE:-af_heart}","response_format":"wav"}' \
+	  --output /tmp/bazan-tts-vi-test.wav \
+	  && echo "Saved: /tmp/bazan-tts-vi-test.wav"
+
+logs-tts:
+	$(COMPOSE) logs -f kokoro-tts

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ Project bao gồm các service chính:
 | RAG API | 8001 | FastAPI search & ingest |
 | Qdrant | 6333 | Vector DB |
 | Ollama | 11434 | LLM API |
+| Kokoro TTS | 8880 | OpenAI-compatible TTS |
+
+## Cấu hình TTS (Open WebUI)
+
+**Admin Panel → Settings → Audio:**
+
+| Field | Giá trị |
+|---|---|
+| TTS Engine | `OpenAI` |
+| API Base URL | `http://kokoro-tts:8880/v1` |
+| API Key | `not-needed` |
+| TTS Voice | `af_heart` |
+| TTS Model | `kokoro` |
+
+```bash
+make tts-voices   # xem danh sách voices
+make tts-test     # test audio
+```
+
+> **Lưu ý tiếng Việt:** Kokoro hiện hỗ trợ English, Japanese, Korean, Chinese.
+> Tiếng Việt đang trong lộ trình. Theo dõi: https://github.com/hexgrad/kokoro
+> Khi có: đổi `KOKORO_DEFAULT_VOICE` trong `.env` — không cần sửa gì khác.
 
 ## Development
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -58,6 +58,26 @@ services:
       retries: 5
       start_period: 15s
 
+  kokoro-tts:
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+    container_name: bazan-kokoro-tts
+    ports:
+      - "${KOKORO_PORT:-8880}:8880"
+    volumes:
+      - kokoro_models:/app/models
+    environment:
+      # Tiếng Việt đang trong lộ trình Kokoro.
+      # Khi có: thay DEFAULT_VOICE thành voice tiếng Việt, không cần sửa gì khác.
+      # Theo dõi: https://github.com/hexgrad/kokoro
+      - DEFAULT_VOICE=${KOKORO_DEFAULT_VOICE:-af_heart}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8880/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
   # data-collector:
   #   build:
   #     context: ../services/data-collector
@@ -73,6 +93,8 @@ volumes:
     name: bazan-webui-data
   qdrant_data:
     name: bazan-qdrant-data
+  kokoro_models:
+    name: bazan-kokoro-models
 
 networks:
   default:


### PR DESCRIPTION
## Summary

Integrates Kokoro-FastAPI as the TTS engine for Bazan AI. Runs on CPU without GPU. OpenAI-compatible API allows direct plug-in to Open WebUI with zero code changes.

## Changes

- `infra/docker-compose.yml` — kokoro-tts service, healthcheck, persistent volume
- `.env.example` — KOKORO_PORT, KOKORO_DEFAULT_VOICE với voice list comment
- `Makefile` — tts-voices, tts-test, tts-test-vi, logs-tts
- `README.md` — Open WebUI TTS config guide + Vietnamese roadmap note

## How to Test

1. `make dev`
2. Chờ kokoro-tts healthy: `make logs-tts`
3. `make tts-test` — generate audio test
4. Open WebUI: Admin → Settings → Audio → set theo README

## Vietnamese Voice Status

Kokoro chưa có tiếng Việt chính thức. Comment sẵn trong `.env.example` và `docker-compose.yml`.
Khi Kokoro upstream merge tiếng Việt: chỉ cần `KOKORO_DEFAULT_VOICE=<vi-voice>` trong `.env`.
Track: https://github.com/hexgrad/kokoro

## Notes for Reviewer

- CPU inference ~2-5s cho câu ngắn, acceptable cho use case nông nghiệp
- Model volume persist qua restart, không cần download lại

Closes #8