### PR TITLE
fix(infra): fix Dify install screen hang

### DIFF
--- a/infra/docker-compose.dify.yml
+++ b/infra/docker-compose.dify.yml
@@ -79,6 +79,9 @@ services:
       SERVICE_API_URL: http://localhost:7001
       APP_API_URL: http://localhost:7001
       APP_WEB_URL: http://localhost:7001
+      
+      # Migration
+      MIGRATION_ENABLED: "true"
 
       # Storage (using local for dev)
       STORAGE_TYPE: local


### PR DESCRIPTION
Enables auto-migration and fixes CONSOLE/APP API URLs for port 7001.