### PR TITLE
fix(infra): add Nginx reverse proxy for Dify

### DIFF
--- a/infra/docker-compose.dify.yml
+++ b/infra/docker-compose.dify.yml
@@ -130,13 +130,26 @@ services:
     image: langgenius/dify-web:0.12.1
     container_name: bazan-dify-web
     restart: always
-    ports:
-      - "${DIFY_PORT:-7001}:3000"
     environment:
       CONSOLE_API_URL: http://localhost:7001/api
       APP_API_URL: http://localhost:7001/api
     depends_on:
       - dify-api
+    networks:
+      - bazan-network
+
+  dify-nginx:
+    image: nginx:1.24.0-alpine
+    container_name: bazan-dify-nginx
+    restart: always
+    ports:
+      - "${DIFY_PORT:-7001}:80"
+    volumes:
+      - ./nginx/dify/conf.d:/etc/nginx/conf.d
+      - ./nginx/dify/proxy_params:/etc/nginx/proxy_params
+    depends_on:
+      - dify-api
+      - dify-web
     networks:
       - bazan-network
 

--- a/infra/nginx/dify/conf.d/default.conf
+++ b/infra/nginx/dify/conf.d/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location /api {
+        proxy_pass http://bazan-dify-api:5001;
+        include /etc/nginx/proxy_params;
+    }
+
+    location /v1 {
+        proxy_pass http://bazan-dify-api:5001;
+        include /etc/nginx/proxy_params;
+    }
+
+    location /console/api {
+        proxy_pass http://bazan-dify-api:5001;
+        include /etc/nginx/proxy_params;
+    }
+
+    location / {
+        proxy_pass http://bazan-dify-web:3000;
+        include /etc/nginx/proxy_params;
+    }
+}

--- a/infra/nginx/dify/proxy_params
+++ b/infra/nginx/dify/proxy_params
@@ -1,0 +1,9 @@
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_http_version 1.1;
+proxy_set_header Connection "";
+proxy_buffering off;
+proxy_read_timeout 3600s;
+proxy_send_timeout 3600s;


### PR DESCRIPTION
Adds Nginx service to route traffic correctly between Dify Web and API on port 7001.